### PR TITLE
v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Contents
         * [Example](#example)
         * [Overview of all command line arguments](#overview-of-all-command-line-arguments)
 * [Documentation](#documentation)
+* [Considerations when drawing graphs](#considerations-when-drawing-graphs)
 * [Feedback, bugs, suggestions](#feedback-bugs-suggestions)
 * [Typical uses](#typical-uses)
 * [For developers](#for-developers)
@@ -36,6 +37,10 @@ The parser tries to be tolerant of small imperfections in the graph creation, at
 It will attempt to infer the types of any integer or date literals, rather than regard them as strings. Again, a parameter can be used to disable this.
 
 By default, the parser outputs a complete, self-contained ontology. This can be tweaked in various ways through command line arguments: for instance all preamble can be omitted, and only individual blocks outputted, which may be convenient if the output will be used to make additions to existing data.
+
+See [Considerations when drawing graphs](#considerations-when-drawing-graphs) for a few points to keep in mind when constructing graphs which you intend to feed through the parser.
+
+Release notes: v0.2 adds several features and fixes a number of bugs/scenarios that were not handled in v0.1. Please upgrade if you are currently using v0.1!
 
 
 Examples
@@ -155,6 +160,7 @@ Then the file `example.owl` can be imported into Protégé, or worked with in an
 
 A number of command line arguments can be passed to the parser, rather than only using it in its most basic form as [above](#basic-use).
 
+
 ##### Example
 
 The following will run the application in 'strict mode' (no attempt made to fix imperfections in the graph XML), and will use four spaces when indenting the outputted OWL.
@@ -222,6 +228,20 @@ Documentation
 Using `--help` as above will output quite thorough documentation of the possible command line arguments. If trying to understand the code, see the docstrings in `draw_io_parser.py`.
 
 
+Considerations when drawing graphs
+----------------------------------
+
+* In the parsing of multi-line text  whether within literal nodes or within the upper half of individual nodes, two or more consecutive line-breaks will be treated as indicating a new paragraph, but single line-breaks will be ignored, that is to say, the two lines will be concatenated without any space being added. Thus, if one wishes to describe a list in a literal node, for instance, which would visually look fine with only a single line-break between items, one should include some kind of separator (a comma plus a single space, or a semi-colon plus a single space, etc), so that the list aspect is not upon parsing.
+* OWL has certain metacharacters that cannot be used in the IRI for an individual (coming from the upper half of an individual node). This includes spaces. The command line option `-m/--metacharacter-substitute` can be used (more than once if necessary) to define substitutes for these metacharacters or to remove them: use `--help` as described in the section [Overview of all command line arguments](#overview-of-all-command-line-arguments) for more details.
+
+  If the parser encounters a metacharacter for which a substitute has not been defined, it will cease parsing and protest! For convenience, you may wish to use `-m remove`, which will simply remove all metacharacters (including spaces) for which you do not specify a substitute (by means of further uses of `-m/--metacharacter-substitute`).
+
+  The handling of capitalisation in connection with replacing or removing spaces can be configured/homogenised using the `-c/--capitalisation-scheme` option. Again, see `--help` for details.
+
+  In all cases, by default, an `rdfs:label` annotation property will be included in the outputted OWL block which records the original text, before it was parsed. In Protégé, this human-readable label is what will typically be displayed; it is only in the actual IRI for an individual that the parsed form is necessary. If you wish to disable the inclusion of the `rdfs:label` annotation property, include the `-l/--label-disable` option when running the script.
+
+
+
 Feedback, bugs, suggestions
 ---------------------------
 
@@ -249,6 +269,11 @@ A github action will be run for every commit or pull request which carries out a
 * `pylint draw_io_parser.py` for linting
 * `autopep8 --in-place draw_io_parser.py` to format the code in-place (replace `--in-place` by `--diff` to see divergences from the PEP 8 style guide)
 
+
+Thanks
+------
+
+I am very grateful to Aaron Hope from the Archives of Ontario for engaging with the parser and the shape library, and for an extremely useful example breaking many things in v0.1 of the parser!
 
 
 License

--- a/examples/knut_olborgs_forskningsnotater.owl
+++ b/examples/knut_olborgs_forskningsnotater.owl
@@ -1,14 +1,19 @@
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 Prefix: rico: <https://www.ica.org/standards/RiC/ontology#>
-Prefix: : <ontology://generated-from-draw-io/2024-04-19T18-54-29#>
-Ontology: <ontology://generated-from-draw-io/2024-04-19T18-54-29>
+Prefix: : <ontology://generated-from-draw-io/2024-04-26T01-32-54#>
+Ontology: <ontology://generated-from-draw-io/2024-04-26T01-32-54>
   Import: <https://raw.githubusercontent.com/ICA-EGAD/RiC-O/master/ontology/current-version/RiC-O_1-0.rdf>
 
 Individual: KnutOlborgsForskingsnotater
+  Annotations:
+    rdfs:label "Knut Olborgs Forskingsnotater"
   Types: rico:RecordSet
   Facts:
     rico:hasCreator KnutOlborg,
     rico:hasSender KnutOlborg,
-    rico:scopeAndContent "Notatene kan være til nytte for andre forskere og studenter som skal arbeidet med dette tyskspråklige og vanskelig tilgjengelige arkivmaterialet. Arkivverket tok imot de digitale filene i 2022. Materialet er elektronisk og består av 105 word-filer (pdf'er).",
+    rico:scopeAndContent "Forskerarkiv. Samling av forsker Knut Olborgs notater fra kildegransking av arkivet RAFA-2197 Deutscher Oberbefehlshaber Norwegen (DOBN). Knut Olborg har gått systematisk gjennom det, eske for eske, og tatt notater.
+
+Notatene kan være til nytte for andre forskere og studenter som skal arbeidet med dette tyskspråklige og vanskelig tilgjengelige arkivmaterialet. Arkivverket tok imot de digitale filene i 2022. Materialet er elektronisk og består av 105 word-filer (pdf'er).",
     rico:isAssociatedWithEvent Okkupasjonstiden,
     rico:isAssociatedWithPlace Norge,
     rico:hasOrHadHolder Arkivverket,
@@ -20,63 +25,89 @@ Individual: KnutOlborgsForskingsnotater
     rico:isRecordResourceAssociatedWithRecordResource DeutscherOberbefehlshaberNorwegenSamling
 
 Individual: KnutOlborg
+  Annotations:
+    rdfs:label "Knut Olborg"
   Types: rico:AgentName, rico:Person
 
 Individual: Okkupasjonstiden
+  Annotations:
+    rdfs:label "Okkupasjonstiden"
   Types: rico:Event
   Facts:
     rico:hasEndDate OkkupasjonstidenSlutt,
     rico:hasBeginningDate OkkupasjonstidenStart
 
 Individual: Norge
+  Annotations:
+    rdfs:label "Norge"
   Types: rico:Place
   Facts:
     rico:hasOrHadPlaceType Country
 
 Individual: NorskBokmål
+  Annotations:
+    rdfs:label "Norsk Bokmål"
   Types: rico:Language
   Facts:
     rico:isOrWasLanguageOf Norge
 
 Individual: Country
+  Annotations:
+    rdfs:label "Country"
   Types: rico:PlaceType
 
 Individual: Arkivverket
-  Types: rico:AgentName, rico:CorporateBody
+  Annotations:
+    rdfs:label "Arkivverket"
+  Types: rico:CorporateBody, rico:AgentName
   Facts:
     rico:name "National Archives of Norway"
 
 Individual: Arkivvesenet
+  Annotations:
+    rdfs:label "Arkivvesenet"
   Types: rico:AgentName
   Facts:
     rico:followsInTime Arkivverket
 
 Individual: KnutOlborgsForskningsnotaterStart
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Start"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2018-08-05"^^xsd:date
 
 Individual: KnutOlborgsForskningsnotaterSlutt
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Slutt"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2021-11-23"^^xsd:date
 
 Individual: Mappestruktur
+  Annotations:
+    rdfs:label "Mappestruktur"
   Types: rico:Mechanism
 
 Individual: KnutOlborgsForskningsnotaterStorageInstantiation
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Storage Instantiation"
   Types: rico:Instantiation
   Facts:
     rico:hasOrHadIdentifier KnutOlborgsForskningsnotaterStorageID,
     rico:hasExtent KnutOlborgsForskningsnotaterTarFileSize
 
 Individual: KnutOlborgsForskningsnotaterStorageID
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Storage ID"
   Types: rico:Identifier
   Facts:
     rico:hasIdentifierType StorageID,
     rico:identifier "d6ef5d07-8b2e-4d7b-9590-a70381765c9a"
 
 Individual: KnutOlborgsForskningsnotaterTarFileSize
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Tar File Size"
   Types: rico:InstantiationExtent
   Facts:
     rico:hasUnitOfMeasurement Bytes,
@@ -84,44 +115,64 @@ Individual: KnutOlborgsForskningsnotaterTarFileSize
     rico:quantity "3676160"^^xsd:integer
 
 Individual: StorageID
+  Annotations:
+    rdfs:label "Storage ID"
   Types: rico:IdentifierType
 
 Individual: Bytes
+  Annotations:
+    rdfs:label "Bytes"
   Types: rico:UnitOfMeasurement
 
 Individual: FileSize
+  Annotations:
+    rdfs:label "File Size"
   Types: rico:ExtentType
 
 Individual: DeutscherOberbefehlshaberNorwegenSamling
+  Annotations:
+    rdfs:label "Deutscher Oberbefehlshaber Norwegen Samling"
   Types: rico:RecordSet
   Facts:
     rico:hasOrHadLanguage Tysk,
-    rico:isAssociatedWithPlace Tyskland,
     rico:isAssociatedWithPlace Norge,
+    rico:isAssociatedWithPlace Tyskland,
     rico:isAssociatedWithEvent Okkupasjonstiden,
-    rico:scopeAndContent "Arkivet var i mange år vært svært lite tilgjengelig for bruk inntil Arkivverket i årene 2016-19 gjennomgikk det og registrerte det i katalog.",
+    rico:scopeAndContent "Et arkiv på om lag 30 hm som ble skapt av tyske militære som var internert i Norge etter krigens slutt. Under alliert kommando måtte de over 350 000 tyskerne administrere seg selv inntil de ble hjemsendt, og dette er arkivet de skapte i den perioden våren 1945 til ut i 1947.
+
+Arkivet var i mange år vært svært lite tilgjengelig for bruk inntil Arkivverket i årene 2016-19 gjennomgikk det og registrerte det i katalog.",
     rico:hasCreator DeutscherOberbefehlshaberNorwegen,
     rico:hasOrHadAnalogueInstantiation DOBNSamlingStorageInstantiation
 
 Individual: Tyskland
+  Annotations:
+    rdfs:label "Tyskland"
   Types: rico:Place
   Facts:
     rico:hasOrHadPlaceType Country
 
 Individual: Tysk
+  Annotations:
+    rdfs:label "Tysk"
   Types: rico:Language
   Facts:
     rico:isOrWasLanguageOf Tyskland
 
 Individual: DeutscherOberbefehlshaberNorwegen
-  Types: rico:AgentName, rico:CorporateBody
+  Annotations:
+    rdfs:label "Deutscher Oberbefehlshaber Norwegen"
+  Types: rico:CorporateBody, rico:AgentName
 
 Individual: DOBNSamlingStorageInstantiation
+  Annotations:
+    rdfs:label "DOBN Samling Storage Instantiation"
   Types: rico:Instantiation
   Facts:
     rico:hasExtent DOBNSamlingShelfSpace
 
 Individual: DOBNSamlingShelfSpace
+  Annotations:
+    rdfs:label "DOBN Samling Shelf Space"
   Types: rico:InstantiationExtent
   Facts:
     rico:hasUnitOfMeasurement Hyllemeter,
@@ -129,17 +180,25 @@ Individual: DOBNSamlingShelfSpace
     rico:quantity "30"^^xsd:integer
 
 Individual: Hyllemeter
+  Annotations:
+    rdfs:label "Hyllemeter"
   Types: rico:UnitOfMeasurement
 
 Individual: ShelfSpace
+  Annotations:
+    rdfs:label "Shelf Space"
   Types: rico:ExtentType
 
 Individual: OkkupasjonstidenSlutt
+  Annotations:
+    rdfs:label "Okkupasjonstiden Slutt"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "1945"^^xsd:integer
 
 Individual: OkkupasjonstidenStart
+  Annotations:
+    rdfs:label "Okkupasjonstiden Start"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "1940"^^xsd:integer

--- a/examples/knut_olborgs_forskningsnotater_without_preamble.owl
+++ b/examples/knut_olborgs_forskningsnotater_without_preamble.owl
@@ -1,9 +1,13 @@
 Individual: KnutOlborgsForskingsnotater
+  Annotations:
+    rdfs:label "Knut Olborgs Forskingsnotater"
   Types: rico:RecordSet
   Facts:
     rico:hasCreator KnutOlborg,
     rico:hasSender KnutOlborg,
-    rico:scopeAndContent "Notatene kan være til nytte for andre forskere og studenter som skal arbeidet med dette tyskspråklige og vanskelig tilgjengelige arkivmaterialet. Arkivverket tok imot de digitale filene i 2022. Materialet er elektronisk og består av 105 word-filer (pdf'er).",
+    rico:scopeAndContent "Forskerarkiv. Samling av forsker Knut Olborgs notater fra kildegransking av arkivet RAFA-2197 Deutscher Oberbefehlshaber Norwegen (DOBN). Knut Olborg har gått systematisk gjennom det, eske for eske, og tatt notater.
+
+Notatene kan være til nytte for andre forskere og studenter som skal arbeidet med dette tyskspråklige og vanskelig tilgjengelige arkivmaterialet. Arkivverket tok imot de digitale filene i 2022. Materialet er elektronisk og består av 105 word-filer (pdf'er).",
     rico:isAssociatedWithEvent Okkupasjonstiden,
     rico:isAssociatedWithPlace Norge,
     rico:hasOrHadHolder Arkivverket,
@@ -15,63 +19,89 @@ Individual: KnutOlborgsForskingsnotater
     rico:isRecordResourceAssociatedWithRecordResource DeutscherOberbefehlshaberNorwegenSamling
 
 Individual: KnutOlborg
+  Annotations:
+    rdfs:label "Knut Olborg"
   Types: rico:AgentName, rico:Person
 
 Individual: Okkupasjonstiden
+  Annotations:
+    rdfs:label "Okkupasjonstiden"
   Types: rico:Event
   Facts:
     rico:hasEndDate OkkupasjonstidenSlutt,
     rico:hasBeginningDate OkkupasjonstidenStart
 
 Individual: Norge
+  Annotations:
+    rdfs:label "Norge"
   Types: rico:Place
   Facts:
     rico:hasOrHadPlaceType Country
 
 Individual: NorskBokmål
+  Annotations:
+    rdfs:label "Norsk Bokmål"
   Types: rico:Language
   Facts:
     rico:isOrWasLanguageOf Norge
 
 Individual: Country
+  Annotations:
+    rdfs:label "Country"
   Types: rico:PlaceType
 
 Individual: Arkivverket
-  Types: rico:AgentName, rico:CorporateBody
+  Annotations:
+    rdfs:label "Arkivverket"
+  Types: rico:CorporateBody, rico:AgentName
   Facts:
     rico:name "National Archives of Norway"
 
 Individual: Arkivvesenet
+  Annotations:
+    rdfs:label "Arkivvesenet"
   Types: rico:AgentName
   Facts:
     rico:followsInTime Arkivverket
 
 Individual: KnutOlborgsForskningsnotaterStart
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Start"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2018-08-05"^^xsd:date
 
 Individual: KnutOlborgsForskningsnotaterSlutt
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Slutt"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2021-11-23"^^xsd:date
 
 Individual: Mappestruktur
+  Annotations:
+    rdfs:label "Mappestruktur"
   Types: rico:Mechanism
 
 Individual: KnutOlborgsForskningsnotaterStorageInstantiation
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Storage Instantiation"
   Types: rico:Instantiation
   Facts:
     rico:hasOrHadIdentifier KnutOlborgsForskningsnotaterStorageID,
     rico:hasExtent KnutOlborgsForskningsnotaterTarFileSize
 
 Individual: KnutOlborgsForskningsnotaterStorageID
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Storage ID"
   Types: rico:Identifier
   Facts:
     rico:hasIdentifierType StorageID,
     rico:identifier "d6ef5d07-8b2e-4d7b-9590-a70381765c9a"
 
 Individual: KnutOlborgsForskningsnotaterTarFileSize
+  Annotations:
+    rdfs:label "Knut Olborgs Forskningsnotater Tar File Size"
   Types: rico:InstantiationExtent
   Facts:
     rico:hasUnitOfMeasurement Bytes,
@@ -79,44 +109,64 @@ Individual: KnutOlborgsForskningsnotaterTarFileSize
     rico:quantity "3676160"^^xsd:integer
 
 Individual: StorageID
+  Annotations:
+    rdfs:label "Storage ID"
   Types: rico:IdentifierType
 
 Individual: Bytes
+  Annotations:
+    rdfs:label "Bytes"
   Types: rico:UnitOfMeasurement
 
 Individual: FileSize
+  Annotations:
+    rdfs:label "File Size"
   Types: rico:ExtentType
 
 Individual: DeutscherOberbefehlshaberNorwegenSamling
+  Annotations:
+    rdfs:label "Deutscher Oberbefehlshaber Norwegen Samling"
   Types: rico:RecordSet
   Facts:
     rico:hasOrHadLanguage Tysk,
     rico:isAssociatedWithPlace Tyskland,
     rico:isAssociatedWithPlace Norge,
     rico:isAssociatedWithEvent Okkupasjonstiden,
-    rico:scopeAndContent "Arkivet var i mange år vært svært lite tilgjengelig for bruk inntil Arkivverket i årene 2016-19 gjennomgikk det og registrerte det i katalog.",
+    rico:scopeAndContent "Et arkiv på om lag 30 hm som ble skapt av tyske militære som var internert i Norge etter krigens slutt. Under alliert kommando måtte de over 350 000 tyskerne administrere seg selv inntil de ble hjemsendt, og dette er arkivet de skapte i den perioden våren 1945 til ut i 1947.
+
+Arkivet var i mange år vært svært lite tilgjengelig for bruk inntil Arkivverket i årene 2016-19 gjennomgikk det og registrerte det i katalog.",
     rico:hasCreator DeutscherOberbefehlshaberNorwegen,
     rico:hasOrHadAnalogueInstantiation DOBNSamlingStorageInstantiation
 
 Individual: Tyskland
+  Annotations:
+    rdfs:label "Tyskland"
   Types: rico:Place
   Facts:
     rico:hasOrHadPlaceType Country
 
 Individual: Tysk
+  Annotations:
+    rdfs:label "Tysk"
   Types: rico:Language
   Facts:
     rico:isOrWasLanguageOf Tyskland
 
 Individual: DeutscherOberbefehlshaberNorwegen
-  Types: rico:AgentName, rico:CorporateBody
+  Annotations:
+    rdfs:label "Deutscher Oberbefehlshaber Norwegen"
+  Types: rico:CorporateBody, rico:AgentName
 
 Individual: DOBNSamlingStorageInstantiation
+  Annotations:
+    rdfs:label "DOBN Samling Storage Instantiation"
   Types: rico:Instantiation
   Facts:
     rico:hasExtent DOBNSamlingShelfSpace
 
 Individual: DOBNSamlingShelfSpace
+  Annotations:
+    rdfs:label "DOBN Samling Shelf Space"
   Types: rico:InstantiationExtent
   Facts:
     rico:hasUnitOfMeasurement Hyllemeter,
@@ -124,17 +174,25 @@ Individual: DOBNSamlingShelfSpace
     rico:quantity "30"^^xsd:integer
 
 Individual: Hyllemeter
+  Annotations:
+    rdfs:label "Hyllemeter"
   Types: rico:UnitOfMeasurement
 
 Individual: ShelfSpace
+  Annotations:
+    rdfs:label "Shelf Space"
   Types: rico:ExtentType
 
 Individual: OkkupasjonstidenSlutt
+  Annotations:
+    rdfs:label "Okkupasjonstiden Slutt"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "1945"^^xsd:integer
 
 Individual: OkkupasjonstidenStart
+  Annotations:
+    rdfs:label "Okkupasjonstiden Start"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "1940"^^xsd:integer

--- a/examples/koronakommisjonen.owl
+++ b/examples/koronakommisjonen.owl
@@ -1,9 +1,12 @@
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 Prefix: rico: <https://www.ica.org/standards/RiC/ontology#>
-Prefix: : <ontology://generated-from-draw-io/2024-04-19T18-53-06#>
-Ontology: <ontology://generated-from-draw-io/2024-04-19T18-53-06>
+Prefix: : <ontology://generated-from-draw-io/2024-04-26T01-31-21#>
+Ontology: <ontology://generated-from-draw-io/2024-04-26T01-31-21>
   Import: <https://raw.githubusercontent.com/ICA-EGAD/RiC-O/master/ontology/current-version/RiC-O_1-0.rdf>
 
 Individual: KoronakommisjonenDokumentasjon
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon"
   Types: rico:RecordSet
   Facts:
     rico:hasCreator Koronakommisjonen,
@@ -20,6 +23,8 @@ Individual: KoronakommisjonenDokumentasjon
     rico:hasOrHadDigitalInstantiation KoronakommisjonenDokumentasjonStoredInstantiation
 
 Individual: Koronakommisjonen
+  Annotations:
+    rdfs:label "Koronakommisjonen"
   Types: rico:AgentName, rico:CorporateBody
   Facts:
     rico:hasBeginningDate InitiationOfKoronakommisjonen,
@@ -27,66 +32,94 @@ Individual: Koronakommisjonen
     rico:isOrWasRegulatedBy KongeligResolusjonKoronakommisjonen
 
 Individual: Covid-19
+  Annotations:
+    rdfs:label "Covid-19"
   Types: rico:Event
 
 Individual: Norge
+  Annotations:
+    rdfs:label "Norge"
   Types: rico:Place
   Facts:
     rico:hasOrHadPlaceType Country
 
 Individual: NorskBokmål
+  Annotations:
+    rdfs:label "Norsk Bokmål"
   Types: rico:Language
   Facts:
     rico:isOrWasLanguageOf Norge
 
 Individual: Country
+  Annotations:
+    rdfs:label "Country"
   Types: rico:PlaceType
 
 Individual: Arkivverket
+  Annotations:
+    rdfs:label "Arkivverket"
   Types: rico:AgentName, rico:CorporateBody
   Facts:
     rico:name "National Archives of Norway"
 
 Individual: Arkivvesenet
+  Annotations:
+    rdfs:label "Arkivvesenet"
   Types: rico:AgentName
   Facts:
     rico:followsInTime Arkivverket
 
 Individual: InitiationOfKoronakommisjonen
+  Annotations:
+    rdfs:label "Initiation of Koronakommisjonen"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2020-04-24"^^xsd:date
 
 Individual: ClosingOfKoronakommisjonen
+  Annotations:
+    rdfs:label "Closing of Koronakommisjonen"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2022-05-06"^^xsd:date
 
 Individual: Sharepoint
+  Annotations:
+    rdfs:label "Sharepoint"
   Types: rico:Mechanism
 
 Individual: KongeligResolusjonKoronakommisjonen
+  Annotations:
+    rdfs:label "Kongelig Resolusjon Koronakommisjonen"
   Types: rico:Rule
   Facts:
     rico:occurredAtDate InitiationOfKoronakommisjonen,
     rico:hasOrHadRuleType KongeligResolusjon
 
 Individual: KongeligResolusjon
+  Annotations:
+    rdfs:label "Kongelig Resolusjon"
   Types: rico:RuleType
 
 Individual: KoronakommisjonenDokumentasjonStoredInstantiation
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon Stored Instantiation"
   Types: rico:Instantiation
   Facts:
     rico:hasOrHadIdentifier KoronakommisjonenDokumentasjonStorageID,
     rico:hasExtent KoronakommisjonenDokumentasjonTarFileSize
 
 Individual: KoronakommisjonenDokumentasjonStorageID
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon Storage ID"
   Types: rico:Identifier
   Facts:
     rico:hasIdentifierType StorageID,
     rico:identifier "96e28e3a-94fd-49e9-af7c-be6c8f60c141"
 
 Individual: KoronakommisjonenDokumentasjonTarFileSize
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon Tar File Size"
   Types: rico:InstantiationExtent
   Facts:
     rico:hasUnitOfMeasurement Bytes,
@@ -94,10 +127,16 @@ Individual: KoronakommisjonenDokumentasjonTarFileSize
     rico:quantity "131070863360"^^xsd:integer
 
 Individual: StorageID
+  Annotations:
+    rdfs:label "Storage ID"
   Types: rico:IdentifierType
 
 Individual: Bytes
+  Annotations:
+    rdfs:label "Bytes"
   Types: rico:UnitOfMeasurement
 
 Individual: FileSize
+  Annotations:
+    rdfs:label "FileSize"
   Types: rico:ExtentType

--- a/examples/koronakommisjonen_without_preamble.owl
+++ b/examples/koronakommisjonen_without_preamble.owl
@@ -1,4 +1,6 @@
 Individual: KoronakommisjonenDokumentasjon
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon"
   Types: rico:RecordSet
   Facts:
     rico:hasCreator Koronakommisjonen,
@@ -15,6 +17,8 @@ Individual: KoronakommisjonenDokumentasjon
     rico:hasOrHadDigitalInstantiation KoronakommisjonenDokumentasjonStoredInstantiation
 
 Individual: Koronakommisjonen
+  Annotations:
+    rdfs:label "Koronakommisjonen"
   Types: rico:CorporateBody, rico:AgentName
   Facts:
     rico:hasBeginningDate InitiationOfKoronakommisjonen,
@@ -22,66 +26,94 @@ Individual: Koronakommisjonen
     rico:isOrWasRegulatedBy KongeligResolusjonKoronakommisjonen
 
 Individual: Covid-19
+  Annotations:
+    rdfs:label "Covid-19"
   Types: rico:Event
 
 Individual: Norge
+  Annotations:
+    rdfs:label "Norge"
   Types: rico:Place
   Facts:
     rico:hasOrHadPlaceType Country
 
 Individual: NorskBokmål
+  Annotations:
+    rdfs:label "Norsk Bokmål"
   Types: rico:Language
   Facts:
     rico:isOrWasLanguageOf Norge
 
 Individual: Country
+  Annotations:
+    rdfs:label "Country"
   Types: rico:PlaceType
 
 Individual: Arkivverket
+  Annotations:
+    rdfs:label "Arkivverket"
   Types: rico:CorporateBody, rico:AgentName
   Facts:
     rico:name "National Archives of Norway"
 
 Individual: Arkivvesenet
+  Annotations:
+    rdfs:label "Arkivvesenet"
   Types: rico:AgentName
   Facts:
     rico:followsInTime Arkivverket
 
 Individual: InitiationOfKoronakommisjonen
+  Annotations:
+    rdfs:label "Initiation of Koronakommisjonen"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2020-04-24"^^xsd:date
 
 Individual: ClosingOfKoronakommisjonen
+  Annotations:
+    rdfs:label "Closing of Koronakommisjonen"
   Types: rico:Date
   Facts:
     rico:normalizedDateValue "2022-05-06"^^xsd:date
 
 Individual: Sharepoint
+  Annotations:
+    rdfs:label "Sharepoint"
   Types: rico:Mechanism
 
 Individual: KongeligResolusjonKoronakommisjonen
+  Annotations:
+    rdfs:label "Kongelig Resolusjon Koronakommisjonen"
   Types: rico:Rule
   Facts:
     rico:occurredAtDate InitiationOfKoronakommisjonen,
     rico:hasOrHadRuleType KongeligResolusjon
 
 Individual: KongeligResolusjon
+  Annotations:
+    rdfs:label "Kongelig Resolusjon"
   Types: rico:RuleType
 
 Individual: KoronakommisjonenDokumentasjonStoredInstantiation
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon Stored Instantiation"
   Types: rico:Instantiation
   Facts:
     rico:hasOrHadIdentifier KoronakommisjonenDokumentasjonStorageID,
     rico:hasExtent KoronakommisjonenDokumentasjonTarFileSize
 
 Individual: KoronakommisjonenDokumentasjonStorageID
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon Storage ID"
   Types: rico:Identifier
   Facts:
     rico:hasIdentifierType StorageID,
     rico:identifier "96e28e3a-94fd-49e9-af7c-be6c8f60c141"
 
 Individual: KoronakommisjonenDokumentasjonTarFileSize
+  Annotations:
+    rdfs:label "Koronakommisjonen Dokumentasjon Tar File Size"
   Types: rico:InstantiationExtent
   Facts:
     rico:hasUnitOfMeasurement Bytes,
@@ -89,10 +121,16 @@ Individual: KoronakommisjonenDokumentasjonTarFileSize
     rico:quantity "131070863360"^^xsd:integer
 
 Individual: StorageID
+  Annotations:
+    rdfs:label "Storage ID"
   Types: rico:IdentifierType
 
 Individual: Bytes
+  Annotations:
+    rdfs:label "Bytes"
   Types: rico:UnitOfMeasurement
 
 Individual: FileSize
+  Annotations:
+    rdfs:label "FileSize"
   Types: rico:ExtentType


### PR DESCRIPTION
A number of features added and bugs fixed/scenarios handled which were not in v0.1.

Features:

* More than one type in an individual node now handled
* Handling of OWL metacharacters and spaces in individual IRIs now configurable (flexibly) by command-line options. An rdfs:label annotation property with the original text in an individual node added by default, can be disabled by a command line option.
* The parser now attempts to give an informative error if one tries to add an arrow between literals.

Bugs fixed/scenarios now handled:

* Geometry guesswork added for literal nodes
* Geometry guesswork tweaked to handle (recursively) the case that the arrow is part of a group
* Linebreaks within text/HTML, for example within literal nodes, now handled in a way which seems about as robust as possible (this was buggy in v0.1, and the bug obscured the need for robust prettification)
* A bug in which metacharacters should have been handled but were not has been fixed
* Various uninformative error messages have been improved to give cell IDs.